### PR TITLE
Use cryptographic random generator

### DIFF
--- a/airctrl/airctrl.py
+++ b/airctrl/airctrl.py
@@ -5,7 +5,7 @@ import base64
 import binascii
 import argparse
 import json
-import random
+import secrets
 import os
 import sys
 import pprint
@@ -47,7 +47,7 @@ class AirClient(object):
     def _get_key(self):
         print('Exchanging secret key with the device ...')
         url = 'http://{}/di/v1/products/0/security'.format(self._host)
-        a = random.getrandbits(256)
+        a = secrets.randbits(256)
         A = pow(G, a, P)
         data = json.dumps({'diffie': format(A, 'x')})
         data_enc = data.encode('ascii')


### PR DESCRIPTION
Although security shouldn't really be a big issue in the communication air purifiiers, it hurts to see the usage of a non cryptographic [random](https://docs.python.org/2/library/random.html#module-random) generator instead of a cryptographic [secure random](https://docs.python.org/3/library/secrets.html#module-secrets) generator.