### PR TITLE
Check session key after load

### DIFF
--- a/airctrl/airctrl.py
+++ b/airctrl/airctrl.py
@@ -87,6 +87,11 @@ class AirClient(object):
                 self._get_key()
         else:
             self._get_key()
+        self._check_key()
+
+    def _check_key(self):
+        url = 'http://{}/di/v1/products/1/air'.format(self._host)
+        self._get(url)
 
     def set_values(self, values, debug=False):
         body = encrypt(values, self._session_key)

--- a/airctrl/airctrl.py
+++ b/airctrl/airctrl.py
@@ -77,17 +77,17 @@ class AirClient(object):
 
     def load_key(self):
         fpath = os.path.expanduser('~/.pyairctrl')
-        if os.path.isfile(fpath):
+        if  os.path.isfile(fpath):
             config = configparser.ConfigParser()
             config.read(fpath)
             if self._host in config['keys']:
                 hex_key = config['keys'][self._host]
                 self._session_key = bytes.fromhex(hex_key)
+                self._check_key()
             else:
                 self._get_key()
         else:
             self._get_key()
-        self._check_key()
 
     def _check_key(self):
         url = 'http://{}/di/v1/products/1/air'.format(self._host)


### PR DESCRIPTION
A changed session key is only handled on get operations. If you set a value and the session key has changed, the communication fails. This PR adds a _get() call after the key is loaded to that a new session key will be generated if is has expired.