### PR TITLE
Coap 1 0 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,17 @@ Active carbon filter: replace in 1565 hours
 HEPA filter: replace in 3965 hours
 ```
 
-Switching the communication protocol
+Switching the version of the communication protocol
 ---
-Use --protocol to switch between communication protocols.
-The following command will try to retrieve the current status using the CoAP protocol:
+Use --version to switch between communication protocols.
+The following command will try to retrieve the current status on devices with version 0.2.1 up to 1.0.7 (not included):
 ```
-$ airctrl --ipaddr 192.168.0.17 --protocol coap
+$ airctrl --ipaddr 192.168.0.17 --version 0.2.1
+```
+
+The following command will try to retrieve the current status on devices with version 1.0.7 and higher:
+```
+$ airctrl --ipaddr 192.168.0.17 --version 1.0.7
 ```
 
 Usage via cloud services

--- a/pyairctrl/airctrl.py
+++ b/pyairctrl/airctrl.py
@@ -621,11 +621,12 @@ class WrongDigestException(Exception):
     pass
 
 class HTTPAirClientBase(ABC):
-    def __init__(self, host, port):
+    def __init__(self, host, port, debug=False):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel("WARN")
         self.server = host
         self.port = port
+        self.debug = debug
 
     def _dump_status(self, status, debug=False):
         if debug==True:
@@ -655,8 +656,8 @@ class HTTPAirClientBase(ABC):
         pass
 
 class Version107Client(HTTPAirClientBase):
-    def __init__(self, host, port=5683):
-        super().__init__(host, port)
+    def __init__(self, host, port=5683, debug=False):
+        super().__init__(host, port, debug)
         self.client = self._create_coap_client(self.server, self.port)
         self.SECRET_KEY='JiangPan'
         self._sync()
@@ -731,7 +732,8 @@ class Version107Client(HTTPAirClientBase):
             payload = {"state":{"desired":{"CommandType":"app","DeviceId":"","EnduserId":"", key: value }}}
             encrypted_payload = self._encrypt_payload(json.dumps(payload))
             response = self.client.post(path, encrypted_payload)
-            print(response)
+            if (self.debug):
+                print(response)
         except Exception as e:
             print("Unexpected error:{}".format(e))
 
@@ -776,7 +778,7 @@ def main():
         elif args.version == '0.2.1':
             c = CoAPAirClient(device['ip'])
         elif args.version == '1.0.7':
-            c = Version107Client(device['ip'])
+            c = Version107Client(device['ip'], debug=args.debug)
 
         if args.wifi:
             c.get_wifi()

--- a/pyairctrl/airctrl.py
+++ b/pyairctrl/airctrl.py
@@ -657,6 +657,9 @@ class Version107Client(HTTPAirClientBase):
         self.SECRET_KEY='JiangPan'
         self._sync()
 
+    def __del__(self):
+        self.client.stop()
+
     def _create_coap_client(self, host, port):
         return HelperClient(server=(host, port))
         
@@ -695,8 +698,8 @@ class Version107Client(HTTPAirClientBase):
             response = self.client.send_request(request, None, 2)
             encrypted_payload = response.payload
             decrypted_payload = self._decrypt_payload(encrypted_payload)
-        finally:
-            self.client.stop()
+        except:
+            print("Unexpected error:", sys.exc_info()[0])
 
         if response:
             return json.loads(decrypted_payload)["state"]["reported"]
@@ -709,8 +712,8 @@ class Version107Client(HTTPAirClientBase):
             payload = {"state":{"desired":{"CommandType":"app","DeviceId":"","EnduserId":"", key: value }}}
             encrypted_payload = self._encrypt_payload(json.dumps(payload))
             self.client.post(path, encrypted_payload, None, None)
-        finally:
-            self.client.stop()
+        except:
+            print("Unexpected error:", sys.exc_info()[0])
 
 def main():
     parser = argparse.ArgumentParser()

--- a/pyairctrl/airctrl.py
+++ b/pyairctrl/airctrl.py
@@ -663,21 +663,26 @@ class HTTPAirClientBase(ABC):
         self.port = port
         self.debug = debug
 
+    def _get_info_for_key(self, key, current_value):
+        if key in statusTransformer:
+            info = statusTransformer[key]
+            if not info[1] is None:
+                current_value = info[1](current_value)
+                if current_value is None:
+                    return None
+            return info[0].format(current_value)
+        else:
+            return '{}: {}'.format(key, current_value)
+
     def _dump_status(self, status, debug=False):
         if debug==True:
-            print("Raw status: " + str(status))
+            print("Raw status:")
+            pprint.pprint(status)
         for key in status:
             current_value=status[key]
-            
-            if key in statusTransformer:
-                info = statusTransformer[key]
-                if not info[1] is None:
-                    current_value = info[1](current_value)
-                    if current_value is None:
-                        continue
-                name_and_value = info[0].format(current_value)
-            else:
-                name_and_value = '{}: {}'.format(key, current_value)
+            name_and_value=self._get_info_for_key(key, current_value)
+            if name_and_value is None:
+                continue
 
             print('[{key}]\t{name_and_value}'.format(key=key, name_and_value=name_and_value).expandtabs(30))
 
@@ -701,6 +706,32 @@ class HTTPAirClientBase(ABC):
     @abstractmethod
     def _set(self, key, value):
         pass
+
+    def get_firmware(self):
+        status = self._get()
+        if status is None:
+            print("No version-info found")
+            return
+
+        print(self._get_info_for_key("swversion", status["swversion"] if "swversion" in status else "nA"))
+        print(self._get_info_for_key("ota", status["ota"] if "ota" in status else "nA"))
+
+    def get_filters(self):
+        status = self._get()
+        if status is None:
+            print("No version-info found")
+            return
+
+        if "fltsts0" in status: print(self._get_info_for_key("fltsts0", status["fltsts0"]))
+        if "fltsts1" in status: print(self._get_info_for_key("fltsts1", status["fltsts1"]))
+        if "fltsts2" in status: print(self._get_info_for_key("fltsts2", status["fltsts2"]))
+        if "wicksts" in status: print(self._get_info_for_key("wicksts", status["wicksts"]))
+
+    def get_wifi(self):
+        print("Getting wifi credentials is currently not supported when using CoAP. Use the app instead.")
+
+    def set_wifi(self, ssid, pwd):
+        print("Setting wifi credentials is currently not supported when using CoAP. Use the app instead.")
 
 class Version107Client(HTTPAirClientBase):
     def __init__(self, host, port=5683, debug=False):


### PR DESCRIPTION
This adds coap-functionality for newer devices as described here: #35

Limitations: 
- Some devices send mutliple coap-messages for one device, these are cut off and information cannot be decrypted (For now users are getting: "Message from device got corrupted"). Known devices:
  - AC2729/50
  - AC3039/10
- At least one device-type can't set aqil 0 or uil 0. Known device:
  - AC3033/10
- Sometimes if you are too fast between two commands, the second command isn't executed. (Solution for now, wait at least 5s) Known devices: 
  - AC2889/10

I'll try to get some information how to fix the limitations, best chances are for AC2889/10 (since I own this device), others will be difficult to test ...

Additional info:
- I added the "aqit" from #12 - I translated it with "Air quality notification threshold", since that's what it is, a treshold for the app notification