### PR TITLE
Add 'a'uto Option to 'om' Field

### DIFF
--- a/pyairctrl/airctrl.py
+++ b/pyairctrl/airctrl.py
@@ -392,7 +392,7 @@ def main():
         default="http",
     )
     parser.add_argument("-d", "--debug", help="show debug output", action="store_true")
-    parser.add_argument("--om", help="set fan speed", choices=["1", "2", "3", "s", "t"])
+    parser.add_argument("--om", help="set fan speed", choices=["1", "2", "3", "s", "t", "a"])
     parser.add_argument("--pwr", help="power on/off", choices=["0", "1"])
     parser.add_argument(
         "--mode", help="set mode", choices=["P", "A", "S", "M", "B", "N"]

--- a/pyairctrl/status_transformer.py
+++ b/pyairctrl/status_transformer.py
@@ -14,7 +14,7 @@ STATUS_TRANSFORMER = {
     "temp" : ("Temperature: {}", None),
     "func" : ("Function: {}", lambda func: {'P': 'Purification', 'PH': 'Purification & Humidification'}.get(func, func)),
     "mode" : ("Mode: {}", lambda mode: {'P': 'auto', 'A': 'allergen', 'S': 'sleep', 'M': 'manual', 'B': 'bacteria', 'N': 'night'}.get(mode, mode)),
-    "om" : ("Fan speed: {}", lambda om: {'s': 'silent', 't': 'turbo'}.get(om, om)),
+    "om" : ("Fan speed: {}", lambda om: {'s': 'silent', 't': 'turbo', 'a': 'auto'}.get(om, om)),
     "aqil" : ("Light brightness: {}", None),
     "aqit" : ("Air quality notification threshold: {}", None),
     "uil" : ("Buttons light: {}", lambda uil: {'1': 'ON', '0': 'OFF'}.get(uil, uil)),


### PR DESCRIPTION
One of the users of my Homebridge plugin reported that at least some COAP-based models use a setting of 'a' in the 'om' field to indicate auto mode, instead of using the 'mode' field.

https://github.com/Sunoo/homebridge-philips-air/issues/9