### PR TITLE
Add debug option to HTTPAirClient. Set default to False

### DIFF
--- a/pyairctrl/airctrl.py
+++ b/pyairctrl/airctrl.py
@@ -96,8 +96,8 @@ class HTTPAirCli:
             pprint.pprint(response)
         return response
 
-    def __init__(self, host):
-        self._client = HTTPAirClient(host)
+    def __init__(self, host, debug=True):
+        self._client = HTTPAirClient(host, debug)
 
     def set_values(self, values, debug=False):
         try:
@@ -156,7 +156,7 @@ class HTTPAirCli:
                 "M": "manual",
                 "B": "bacteria",
                 "N": "night",
-                "T": "turbo",                
+                "T": "turbo",
             }
             mode = mode_str.get(mode, mode)
             print("[mode]  Mode: {}".format(mode))
@@ -288,7 +288,7 @@ class PlainCoAPAirCli:
                 "M": "manual",
                 "B": "bacteria",
                 "N": "night",
-                "T": "turbo",               
+                "T": "turbo",
             }
             mode = mode_str.get(mode, mode)
             print("[mode]        Mode: {}".format(mode))

--- a/pyairctrl/http_client.py
+++ b/pyairctrl/http_client.py
@@ -101,13 +101,15 @@ class HTTPAirClient:
 
         return resp
 
-    def __init__(self, host):
+    def __init__(self, host, debug=False):
         self._host = host
         self._session_key = None
+        self._debug = debug
         self.load_key()
 
     def _get_key(self):
-        print("Exchanging secret key with the device ...")
+        if self._debug:
+            print("Exchanging secret key with the device ...")
         url = "http://{}/di/v1/products/0/security".format(self._host)
         a = random.getrandbits(256)
         A = pow(G, a, P)
@@ -133,7 +135,9 @@ class HTTPAirClient:
             config["keys"] = {}
         hex_key = binascii.hexlify(self._session_key).decode("ascii")
         config["keys"][self._host] = hex_key
-        print("Saving session_key {} to {}".format(hex_key, fpath))
+
+        if self._debug:
+            print("Saving session_key {} to {}".format(hex_key, fpath))
         with open(fpath, "w") as f:
             config.write(f)
 
@@ -192,8 +196,9 @@ class HTTPAirClient:
         try:
             return self._get_once(url)
         except Exception as e:
-            print("GET error: {}".format(str(e)))
-            print("Will retry after getting a new key ...")
+            if self._debug:
+                print("GET error: {}".format(str(e)))
+                print("Will retry after getting a new key ...")
             self._get_key()
             return self._get_once(url)
 


### PR DESCRIPTION
I want to use `pi-air-control` in a custom Home Assistant component, wrapping it in asyncio. Home Assistant is complaining when it detects I/O in it's event loop.

This adds `debug` option to `HTTPAirClient` similar to `CoAPAirClient`. When `debug` is `False`, the client won't print.

For instances of `HTTPAirClient` debug defaults to `False`. For `HTTPAirCli` it defaults to `True` to preserve current behavior.

I suggest passing the debug value from `args.debug` to `HTTPAirCli` in the future, but that will change the current behavior.