### PR TITLE
Update dependency of CoAPython from github.com/rgerganov/CoAPthon3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Python 3.4+ is required. Install with `pip3`:
 ```
 $ pip3 install py-air-control
 ```
-If your device is using CoAP then update the `CoAPthon3` dependency to get fixes for several known bugs:
-```
-$ pip3 install -U git+https://github.com/rgerganov/CoAPthon3
-```
 
 Wi-Fi setup
 ---

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=['pyairctrl'],
     install_requires=[
         'pycryptodomex>=3.4.7',
-        'CoAPthon3>=1.0.1'
+        'CoAPthon3 @ git+https://github.com/rgerganov/CoAPthon3',
         ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Verified on my localhost. It installs CoAPython from rgerganov repo directly.

```
root@8528c3b38a28:/# pip3 install -U git+https://github.com/googollee/py-air-control
Collecting git+https://github.com/googollee/py-air-control
  Cloning https://github.com/googollee/py-air-control to /tmp/pip-req-build-c95ulkyd
  Running command git clone -q https://github.com/googollee/py-air-control /tmp/pip-req-build-c95ulkyd
Collecting CoAPthon3@ git+https://github.com/rgerganov/CoAPthon3
  Cloning https://github.com/rgerganov/CoAPthon3 to /tmp/pip-install-0pg7zfc8/coapthon3_463f4cbd4f664620adf208741c2d6773
  Running command git clone -q https://github.com/rgerganov/CoAPthon3 /tmp/pip-install-0pg7zfc8/coapthon3_463f4cbd4f664620adf208741c2d6773
Collecting pycryptodomex>=3.4.7
  Downloading pycryptodomex-3.10.1-cp35-abi3-manylinux2010_x86_64.whl (1.9 MB)
     |████████████████████████████████| 1.9 MB 2.5 MB/s 
Building wheels for collected packages: py-air-control, CoAPthon3
  Building wheel for py-air-control (setup.py) ... done
  Created wheel for py-air-control: filename=py_air_control-2.2.0-py3-none-any.whl size=18572 sha256=dccd1c29c3f55f411ee13de2587af2dc05d6b870ede99143bb852dc283e1580b
  Stored in directory: /tmp/pip-ephem-wheel-cache-1d5u2yj3/wheels/0a/c3/b9/c4b6f8be3cd35972e4c6eaaf5f89311d97b58c065f3c220cad
  Building wheel for CoAPthon3 (setup.py) ... done
  Created wheel for CoAPthon3: filename=CoAPthon3-1.0.1-py3-none-any.whl size=62031 sha256=2d5f003eeb7a4dff71022c79e39145093ce5cf8bab4c33494dab73e997cc5945
  Stored in directory: /tmp/pip-ephem-wheel-cache-1d5u2yj3/wheels/5c/04/42/b57957772fff6601c7975e1ac03adbfc0095a96bdf0e4ba171
Successfully built py-air-control CoAPthon3
Installing collected packages: pycryptodomex, CoAPthon3, py-air-control
Successfully installed CoAPthon3-1.0.1 py-air-control-2.2.0 pycryptodomex-3.10.1
```