### PR TITLE
Spike aiocoap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Python 3.4+ is required. Install with `pip3`:
 ```
 $ pip3 install py-air-control
 ```
-If your device is using CoAP then update the `CoAPthon3` dependency to get fixes for several known bugs:
-```
-$ pip3 install -U git+https://github.com/rgerganov/CoAPthon3
-```
 
 Wi-Fi setup
 ---

--- a/pyairctrl/aiocoap_monkeypatch.py
+++ b/pyairctrl/aiocoap_monkeypatch.py
@@ -1,0 +1,40 @@
+import asyncio
+import functools
+
+from aiocoap.messagemanager import MessageManager
+from aiocoap.numbers.constants import EXCHANGE_LIFETIME
+
+
+def _deduplicate_message(self, message):
+    key = (message.remote, message.mid)
+    self.log.debug("MP: New unique message received")
+    self.loop.call_later(
+        EXCHANGE_LIFETIME, functools.partial(self._recent_messages.pop, key)
+    )
+    self._recent_messages[key] = None
+    return False
+
+
+MessageManager._deduplicate_message = _deduplicate_message
+
+from aiocoap.protocol import ClientObservation
+from aiocoap.error import ObservationCancelled, NotObservable, LibraryShutdown
+
+
+def __del__(self):
+    if self._future.done():
+        try:
+            # Fetch the result so any errors show up at least in the
+            # finalizer output
+            self._future.result()
+        except (ObservationCancelled, NotObservable):
+            # This is the case at the end of an observation cancelled
+            # by the server.
+            pass
+        except LibraryShutdown:
+            pass
+        except asyncio.CancelledError:
+            pass
+
+
+ClientObservation._Iterator.__del__ = __del__

--- a/pyairctrl/coap_client.py
+++ b/pyairctrl/coap_client.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 
 from coapthon import defines
 from coapthon.client.helperclient import HelperClient
+from coapthon.messages.request import Request
 from Cryptodome.Cipher import AES
 from Cryptodome.Util.Padding import pad, unpad
 
@@ -24,13 +25,28 @@ class NotSupportedException(Exception):
     pass
 
 
-class HTTPAirClientBase(ABC):
+class CoAPAirClientBase(ABC):
+    STATUS_PATH = "/sys/dev/status"
+    CONTROL_PATH = "/sys/dev/control"
+    SYNC_PATH = "/sys/dev/sync"
+
     def __init__(self, host, port, debug=False):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel("WARN")
         self.server = host
         self.port = port
         self.debug = debug
+        self.client = self._create_coap_client(self.server, self.port)
+        self.response = None
+        self._initConnection()
+
+    def __del__(self):
+        if self.response:
+            self.client.cancel_observing(self.response, True)
+        self.client.stop()
+
+    def _create_coap_client(self, host, port):
+        return HelperClient(server=(host, port))
 
     def get_status(self, debug=False):
         if debug:
@@ -48,20 +64,65 @@ class HTTPAirClientBase(ABC):
 
         return result
 
-    @abstractmethod
     def _get(self):
+        payload = None
+
+        try:
+            request = self.client.mk_request(defines.Codes.GET, self.STATUS_PATH)
+            request.observe = 0
+            self.response = self.client.send_request(request, None, 2)
+            if self.response:
+                payload = self._transform_payload_after_receiving(self.response.payload)
+        except Exception as e:
+            print("Unexpected error:{}".format(e))
+
+        if payload:
+            try:
+                return json.loads(payload, object_pairs_hook=OrderedDict)["state"][
+                    "reported"
+                ]
+            except json.decoder.JSONDecodeError:
+                print("JSONDecodeError, you may have choosen the wrong coap protocol!")
+
+        return {}
+
+    def _set(self, key, payload):
+        try:
+            payload = self._transform_payload_before_sending(json.dumps(payload))
+            response = self.client.post(self.CONTROL_PATH, payload)
+
+            if self.debug:
+                print(response)
+            return response.payload == '{"status":"success"}'
+        except Exception as e:
+            print("Unexpected error:{}".format(e))
+
+    def _send_empty_message(self):
+        request = Request()
+        request.destination = server = (self.server, self.port)
+        request.code = defines.Codes.EMPTY.number
+        self.client.send_empty(request)
+
+    @abstractmethod
+    def _initConnection(self):
         pass
 
     @abstractmethod
-    def _set(self, key, value):
+    def _transform_payload_after_receiving(self, payload):
+        pass
+
+    @abstractmethod
+    def _transform_payload_before_sending(self, payload):
         pass
 
     def get_firmware(self):
         status = self._get()
+        # TODO Really transmit full status here?
         return status
 
     def get_filters(self):
         status = self._get()
+        # TODO Really transmit full status here?
         return status
 
     def get_wifi(self):
@@ -71,50 +132,43 @@ class HTTPAirClientBase(ABC):
         raise NotSupportedException
 
 
-class CoAPAirClient(HTTPAirClientBase):
+class CoAPAirClient(CoAPAirClientBase):
     SECRET_KEY = "JiangPan"
 
     def __init__(self, host, port=5683, debug=False):
         super().__init__(host, port, debug)
-        self.client = self._create_coap_client(self.server, self.port)
-        self.response = None
-        self._sync()
 
-    def __del__(self):
-        # TODO call a close method explicitly instead
-        if self.response:
-            self.client.cancel_observing(self.response, True)        
-        self.client.stop()        
-
-    def _create_coap_client(self, host, port):
-        return HelperClient(server=(host, port))
-
-    def _sync(self):
+    def _initConnection(self):
         self.syncrequest = binascii.hexlify(os.urandom(4)).decode("utf8").upper()
-        resp = self.client.post("/sys/dev/sync", self.syncrequest, timeout=5)
+        resp = self.client.post(self.SYNC_PATH, self.syncrequest, timeout=5)
         if resp:
             self.client_key = resp.payload
         else:
             self.client.stop()
             raise Exception("sync timeout")
 
-    def _decrypt_payload(self, encrypted_payload):
-        encoded_counter = encrypted_payload[0:8]
-        aes = self._handle_AES(encoded_counter)
-        encoded_message = encrypted_payload[8:-64].upper()
-        digest = encrypted_payload[-64:]
-        calculated_digest = self._create_digest(encoded_counter, encoded_message)
-        if digest != calculated_digest:
-            raise WrongDigestException
-        decoded_message = aes.decrypt(bytes.fromhex(encoded_message))
-        unpaded_message = unpad(decoded_message, 16, style="pkcs7")
-        return unpaded_message.decode("utf8")
+    def _transform_payload_after_receiving(self, encrypted_payload):
+        try:
+            encoded_counter = encrypted_payload[0:8]
+            aes = self._handle_AES(encoded_counter)
+            encoded_message = encrypted_payload[8:-64].upper()
+            digest = encrypted_payload[-64:]
+            calculated_digest = self._create_digest(encoded_counter, encoded_message)
+            if digest != calculated_digest:
+                raise WrongDigestException
+            decoded_message = aes.decrypt(bytes.fromhex(encoded_message))
+            unpaded_message = unpad(decoded_message, 16, style="pkcs7")
+            return unpaded_message.decode("utf8")
+        except WrongDigestException:
+            print("Message from device got corrupted")
 
-    def _encrypt_payload(self, payload):
+    def _transform_payload_before_sending(self, payload):
         self._update_client_key()
         aes = self._handle_AES(self.client_key)
         paded_message = pad(bytes(payload.encode("utf8")), 16, style="pkcs7")
-        encoded_message = binascii.hexlify(aes.encrypt(paded_message)).decode("utf8").upper()
+        encoded_message = (
+            binascii.hexlify(aes.encrypt(paded_message)).decode("utf8").upper()
+        )
         digest = self._create_digest(self.client_key, encoded_message)
         return self.client_key + encoded_message + digest
 
@@ -138,45 +192,15 @@ class CoAPAirClient(HTTPAirClientBase):
             bytes(secret_key.encode("utf8")), AES.MODE_CBC, bytes(iv.encode("utf8"))
         )
 
-    def _get(self):
-        path = "/sys/dev/status"
-        decrypted_payload = None
-
-        try:
-            request = self.client.mk_request(defines.Codes.GET, path)
-            request.observe = 0
-            self.response = self.client.send_request(request, None, 2)
-            encrypted_payload = self.response.payload
-            decrypted_payload = self._decrypt_payload(encrypted_payload)
-        except WrongDigestException:
-            print("Message from device got corrupted")
-        except Exception as e:
-            print("Unexpected error:{}".format(e))
-
-        if decrypted_payload is not None:
-            return json.loads(decrypted_payload, object_pairs_hook=OrderedDict)[
-                "state"
-            ]["reported"]
-        else:
-            return {}
-
     def _set(self, key, value):
-        path = "/sys/dev/control"
-        try:
-            payload = {
-                "state": {
-                    "desired": {
-                        "CommandType": "app",
-                        "DeviceId": "",
-                        "EnduserId": "",
-                        key: value,
-                    }
+        payload = {
+            "state": {
+                "desired": {
+                    "CommandType": "app",
+                    "DeviceId": "",
+                    "EnduserId": "",
+                    key: value,
                 }
             }
-            encrypted_payload = self._encrypt_payload(json.dumps(payload))
-            response = self.client.post(path, encrypted_payload)
-            if self.debug:
-                print(response)
-            return response.payload == '{"status":"success"}'
-        except Exception as e:
-            print("Unexpected error:{}".format(e))
+        }
+        return super()._set(key, payload)

--- a/pyairctrl/plain_coap_client.py
+++ b/pyairctrl/plain_coap_client.py
@@ -13,12 +13,13 @@ import time
 from collections import OrderedDict
 from .coap_client import CoAPAirClientBase
 
+
 class PlainCoAPAirClient(CoAPAirClientBase):
     def __init__(self, host, port=5683, debug=False):
         super().__init__(host, port, debug)
         # TODO is this really needed for _get?
-        #request.type = defines.Types["ACK"]
-        #request.token = generate_random_token(4)
+        # request.type = defines.Types["ACK"]
+        # request.token = generate_random_token(4)
 
     def _set(self, key, value):
         payload = {"state": {"desired": {key: value}}}
@@ -153,7 +154,7 @@ class PlainCoAPAirClient(CoAPAirClientBase):
         tcp = struct.pack(
             "!BBHHHBBH4s4s",
             ip_ver,  # IP Version
-            ip_dfc,  # Differentiate Service Feild
+            ip_dfc,  # Differentiate Service Field
             ip_tol,  # Total Length
             ip_idf,  # Identification
             ip_flg,  # Flags

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pycryptodomex>=3.4.7
-# see https://github.com/Tanganelli/CoAPthon3/issues/29
-CoAPthon3 @ git+https://github.com/Tanganelli/CoAPthon3@89d5173
+aiocoap=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=['pyairctrl'],
     install_requires=[
         'pycryptodomex>=3.4.7',
-        'CoAPthon3>=1.0.1'
+        'aiocoap==0.4.1'
         ],
     entry_points={
         'console_scripts': [

--- a/testing/test_coap.py
+++ b/testing/test_coap.py
@@ -58,7 +58,7 @@ class TestCoap:
         yield server
         server.stop()
 
-    def test_sync_was_called(self, air_client):
+    def test_initConnection_was_called(self, air_client):
         assert air_client.client_key == SyncResource.SYNC_KEY
 
     def test_set_values(self, air_client):

--- a/testing/test_plain_coap.py
+++ b/testing/test_plain_coap.py
@@ -61,77 +61,71 @@ class TestPlainCoap:
         yield server
         server.stop()
 
-    def test_set_values(self, air_client, monkeypatch):
+    def test_set_values(self, air_client):
         values = {}
         values["mode"] = "A"
         result = air_client.set_values(values)
         assert result
 
-    def test_get_status_is_valid(self, air_client, test_data, monkeypatch):
+    def test_get_status_is_valid(self, air_client, test_data):
         self.assert_json_data(
             air_client.get_status,
             "status",
             test_data,
-            monkeypatch,
             air_client,
         )
 
-    def test_get_firmware_is_valid(self, air_client, test_data, monkeypatch):
+    def test_get_firmware_is_valid(self, air_client, test_data):
         self.assert_json_data(
             air_client.get_firmware,
             "status",
             test_data,
-            monkeypatch,
             air_client,
         )
 
-    def test_get_filters_is_valid(self, air_client, test_data, monkeypatch):
+    def test_get_filters_is_valid(self, air_client, test_data):
         self.assert_json_data(
             air_client.get_filters,
             "status",
             test_data,
-            monkeypatch,
             air_client,
         )
 
-    def test_get_cli_status_is_valid(self, air_cli, test_data, monkeypatch, capfd):
+    def test_get_cli_status_is_valid(self, air_cli, test_data, capfd):
         self.assert_cli_data(
             air_cli.get_status,
             "status-cli",
             test_data,
-            monkeypatch,
             air_cli,
             capfd,
         )
 
-    def test_get_cli_firmware_is_valid(self, air_cli, test_data, monkeypatch, capfd):
+    def test_get_cli_firmware_is_valid(self, air_cli, test_data, capfd):
         self.assert_cli_data(
             air_cli.get_firmware,
             "firmware-cli",
             test_data,
-            monkeypatch,
             air_cli,
             capfd,
         )
 
-    def test_get_cli_filters_is_valid(self, air_cli, test_data, monkeypatch, capfd):
+    def test_get_cli_filters_is_valid(self, air_cli, test_data, capfd):
         self.assert_cli_data(
             air_cli.get_filters,
             "fltsts-cli",
             test_data,
-            monkeypatch,
             air_cli,
             capfd,
         )
 
-    def assert_json_data(self, air_func, dataset, test_data, monkeypatch, air_client):
+    def assert_json_data(self, air_func, dataset, test_data, air_client):
         result = air_func()
         data = test_data["plain-coap"][dataset]["data"]
         json_data = json.loads(data)
         assert result == json_data
 
     def assert_cli_data(
-        self, air_func, dataset, test_data, monkeypatch, air_cli, capfd
+        self, air_func, dataset, test_data, air_cli, capfd
     ):
         air_func()
         result, err = capfd.readouterr()

--- a/testing/test_plain_coap.py
+++ b/testing/test_plain_coap.py
@@ -50,10 +50,10 @@ class TestPlainCoap:
         server.stop()
 
     def test_set_values(self, air_client, monkeypatch):
-        def send_hello_sequence(client):
+        def initConnection(client):
             return
 
-        monkeypatch.setattr(air_client, "_send_hello_sequence", send_hello_sequence)
+        monkeypatch.setattr(air_client, "_initConnection", initConnection)
 
         values = {}
         values["mode"] = "A"
@@ -96,10 +96,10 @@ class TestPlainCoap:
         )
 
     def assert_json_data(self, air_func, dataset, test_data, monkeypatch, air_client):
-        def send_hello_sequence(client):
+        def initConnection(client):
             return
 
-        monkeypatch.setattr(air_client, "_send_hello_sequence", send_hello_sequence)
+        monkeypatch.setattr(air_client, "_initConnection", initConnection)
 
         result = air_func()
         data = test_data["plain-coap"][dataset]["data"]
@@ -109,11 +109,11 @@ class TestPlainCoap:
     def assert_cli_data(
         self, air_func, dataset, test_data, monkeypatch, air_cli, capfd
     ):
-        def send_hello_sequence(client):
+        def initConnection(client):
             return
 
         monkeypatch.setattr(
-            air_cli._client, "_send_hello_sequence", send_hello_sequence
+            air_cli._client, "_initConnection", initConnection
         )
 
         air_func()

--- a/testing/test_plain_coap.py
+++ b/testing/test_plain_coap.py
@@ -11,7 +11,19 @@ from plain_coap_resources import ControlResource, StatusResource
 
 class TestPlainCoap:
     @pytest.fixture(scope="class")
-    def air_client(self):
+    def monkeyclass(self):
+        from _pytest.monkeypatch import MonkeyPatch
+
+        mpatch = MonkeyPatch()
+        yield mpatch
+        mpatch.undo()
+
+    @pytest.fixture(scope="class")
+    def air_client(self, monkeyclass):
+        def initConnection(client):
+            return
+
+        monkeyclass.setattr(PlainCoAPAirClient, "_initConnection", initConnection)
         return PlainCoAPAirClient("127.0.0.1")
 
     @pytest.fixture(scope="class")
@@ -50,11 +62,6 @@ class TestPlainCoap:
         server.stop()
 
     def test_set_values(self, air_client, monkeypatch):
-        def initConnection(client):
-            return
-
-        monkeypatch.setattr(air_client, "_initConnection", initConnection)
-
         values = {}
         values["mode"] = "A"
         result = air_client.set_values(values)
@@ -62,22 +69,39 @@ class TestPlainCoap:
 
     def test_get_status_is_valid(self, air_client, test_data, monkeypatch):
         self.assert_json_data(
-            air_client.get_status, "status", test_data, monkeypatch, air_client,
+            air_client.get_status,
+            "status",
+            test_data,
+            monkeypatch,
+            air_client,
         )
 
     def test_get_firmware_is_valid(self, air_client, test_data, monkeypatch):
         self.assert_json_data(
-            air_client.get_firmware, "status", test_data, monkeypatch, air_client,
+            air_client.get_firmware,
+            "status",
+            test_data,
+            monkeypatch,
+            air_client,
         )
 
     def test_get_filters_is_valid(self, air_client, test_data, monkeypatch):
         self.assert_json_data(
-            air_client.get_filters, "status", test_data, monkeypatch, air_client,
+            air_client.get_filters,
+            "status",
+            test_data,
+            monkeypatch,
+            air_client,
         )
 
     def test_get_cli_status_is_valid(self, air_cli, test_data, monkeypatch, capfd):
         self.assert_cli_data(
-            air_cli.get_status, "status-cli", test_data, monkeypatch, air_cli, capfd,
+            air_cli.get_status,
+            "status-cli",
+            test_data,
+            monkeypatch,
+            air_cli,
+            capfd,
         )
 
     def test_get_cli_firmware_is_valid(self, air_cli, test_data, monkeypatch, capfd):
@@ -92,15 +116,15 @@ class TestPlainCoap:
 
     def test_get_cli_filters_is_valid(self, air_cli, test_data, monkeypatch, capfd):
         self.assert_cli_data(
-            air_cli.get_filters, "fltsts-cli", test_data, monkeypatch, air_cli, capfd,
+            air_cli.get_filters,
+            "fltsts-cli",
+            test_data,
+            monkeypatch,
+            air_cli,
+            capfd,
         )
 
     def assert_json_data(self, air_func, dataset, test_data, monkeypatch, air_client):
-        def initConnection(client):
-            return
-
-        monkeypatch.setattr(air_client, "_initConnection", initConnection)
-
         result = air_func()
         data = test_data["plain-coap"][dataset]["data"]
         json_data = json.loads(data)
@@ -109,13 +133,6 @@ class TestPlainCoap:
     def assert_cli_data(
         self, air_func, dataset, test_data, monkeypatch, air_cli, capfd
     ):
-        def initConnection(client):
-            return
-
-        monkeypatch.setattr(
-            air_cli._client, "_initConnection", initConnection
-        )
-
         air_func()
         result, err = capfd.readouterr()
 


### PR DESCRIPTION
Depends on #86

## Description
- uses https://github.com/chrysn/aiocoap instead of https://github.com/Tanganelli/CoAPthon3
- added monkeypatch from here https://github.com/betaboon/aioairctrl/blob/master/aioairctrl/coap/aiocoap_monkeypatch.py (see https://github.com/betaboon/aioairctrl/issues/3), needed for some devices

## Advantages
- aiocoap seems to be better supported, used more often (more commits, stars, forks)
- newer pypi-package (Februar 2021 opposed to January 2018)
- we had some bigger troubles with coapthon3, therefore needed to clone this, seems that this library is more stable.

## Disadvantages
- need to change infrastructure, since it uses asyncio
- lowest version would be python 3.7, here we are using 3.4 or higher, so we would need to change this requirement

---
## Disclaimer
This is just a spike working with coap only:
    - no adjustments to http and plain_coap (need to change to asyncio)
    - no adjustments on base-classes (changed coap-class directly)
    - no adjustments to tests

---

For coap it works like it worked with Coapthon3, some work will still be needed, just not sure if we should make this step, **I think I'll make some changes like mqtt + usage of observable before**. 
Therefore I made only a draft PR.